### PR TITLE
chore: small gas optimization in a loop

### DIFF
--- a/contracts/Rln.sol
+++ b/contracts/Rln.sol
@@ -36,8 +36,11 @@ contract RLN {
         poseidonHasher = IPoseidonHasher(_poseidonHasher);
         SET_SIZE = 1 << DEPTH;
         if (constructMembers.length > SET_SIZE) revert FullTree();
-        for (uint256 i = 0; i < constructMembers.length; i++) {
+        for (uint256 i = 0; i < constructMembers.length;) {
             _register(constructMembers[i]);
+            unchecked {
+                ++i;
+            }
         }
     }
 


### PR DESCRIPTION
This PR does a tiny gas optimization of the loop in the contract

It is safe to do unchecked `++i` as the array we loop over will never be longer than `uint256`. 